### PR TITLE
fix: update SPA fallback route for Express 5 compatibility

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -76,8 +76,8 @@ if (config.nodeEnv === 'production') {
   const clientPath = path.resolve(__dirname, '../client');
   app.use(express.static(clientPath));
 
-  // SPA fallback
-  app.get('*', (_req, res) => {
+  // SPA fallback - Express 5 requires named wildcard parameter
+  app.get('*splat', (_req, res) => {
     res.sendFile(path.join(clientPath, 'index.html'));
   });
 }


### PR DESCRIPTION
Express 5 uses path-to-regexp v8 which requires named wildcard parameters. Changed '*' to '*splat' to fix "Missing parameter name" error when running in production mode.