### PR TITLE
fix(ci): add tag_pattern to git-cliff config

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -25,6 +25,8 @@ split_commits = false
 protect_breaking_commits = false
 # Filter out commits that match this regex
 filter_commits = false
+# Regex for matching git tags (version tags)
+tag_pattern = "v[0-9].*"
 # Sort commits by date
 sort_commits = "newest"
 


### PR DESCRIPTION
Fixes SetCommitRangeError when running git-cliff with version tags. Without tag_pattern, git-cliff interprets version arguments like v1.0.0 as commit OIDs instead of tag references.