### PR TITLE
fix(ci): hardcode github remote in cliff.toml

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -62,5 +62,5 @@ link_parsers = [
 ]
 
 [remote.github]
-owner = "{{ get_env(name=\"GITHUB_REPOSITORY_OWNER\", default=\"\") }}"
-repo = "{{ get_env(name=\"GITHUB_REPOSITORY\", default=\"\") | split(pat=\"/\") | last }}"
+owner = "Xenolphthalein"
+repo = "firefly-toolbox"


### PR DESCRIPTION
Template functions like get_env() cannot be used in TOML config values, only in the changelog body template. Fixes 404 errors when git-cliff tries to fetch GitHub metadata.