### PR TITLE
fix: show correct disabled reason for FinTS tool when product ID is missing

### DIFF
--- a/src/client/composables/useTools.ts
+++ b/src/client/composables/useTools.ts
@@ -163,7 +163,9 @@ export function useTools(): UseToolsReturn {
       // Determine disabled reason from backend requiresConfig
       let disabledReason = '';
       if (!available && backendStatus?.requiresConfig) {
-        if (backendStatus.requiresConfig.includes('AI_PROVIDER')) {
+        if (backendStatus.requiresConfig.includes('FINTS_PRODUCT_ID')) {
+          disabledReason = 'FinTS Product ID required';
+        } else if (backendStatus.requiresConfig.includes('AI_PROVIDER')) {
           disabledReason = 'Configure AI first';
         } else if (backendStatus.requiresConfig.includes('FIREFLY_API_URL')) {
           disabledReason = 'Connect to FireflyIII first';


### PR DESCRIPTION
When the FinTS Product ID is not configured, the tool now shows 'FinTS Product ID required' instead of 'Connect to FireflyIII first'.

The issue was that the disabled reason logic didn't handle the FINTS_PRODUCT_ID config requirement, falling through to the generic FireflyIII message.