### PR TITLE
fix(ci): skip merge commits in changelog generation

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -32,7 +32,14 @@ sort_commits = "newest"
 
 # Commit groups and their display names
 commit_parsers = [
+  # Skip merge commits
+  { message = "^Merge pull request", skip = true },
+  { message = "^Merge branch", skip = true },
+  # Skip release commits
+  { message = "^chore\\(release\\)", skip = true },
+  # Conventional commit types with scopes (order matters - more specific first)
   { message = "^feat", group = "✨ Features" },
+  { message = "^fix\\(deps\\)", group = "📦 Dependencies" },
   { message = "^fix", group = "🐛 Bug Fixes" },
   { message = "^doc", group = "📚 Documentation" },
   { message = "^perf", group = "⚡ Performance" },
@@ -41,7 +48,6 @@ commit_parsers = [
   { message = "^test", group = "🧪 Testing" },
   { message = "^build", group = "🏗️ Build" },
   { message = "^ci", group = "👷 CI/CD" },
-  { message = "^chore\\(release\\)", skip = true },
   { message = "^chore\\(deps\\)", group = "📦 Dependencies" },
   { message = "^chore", group = "🔧 Miscellaneous" },
   { message = "^revert", group = "⏪ Reverted" },


### PR DESCRIPTION
This pull request updates the `cliff.toml` configuration to improve how commits are parsed and grouped for changelog generation. The main changes focus on better handling of merge and release commits, and more precise grouping for dependency-related changes.

**Commit filtering and grouping improvements:**

* Added rules to skip merge commits (`^Merge pull request`, `^Merge branch`) and release commits (`^chore(release)`), ensuring these are excluded from changelogs.
* Introduced a new parser to group dependency fixes (`^fix(deps)`) under the "📦 Dependencies" section for clearer changelog organization.
* Moved the rule to skip release commits earlier in the list, ensuring it takes precedence over other parsers.