### PR TITLE
fix: update license from MIT to Unlicense in About card

### DIFF
--- a/src/client/views/SettingsView.vue
+++ b/src/client/views/SettingsView.vue
@@ -281,7 +281,7 @@
             </div>
             <div class="d-flex align-center justify-space-between">
               <span class="text-body-2 text-medium-emphasis">License</span>
-              <span class="text-body-2 font-weight-medium">MIT</span>
+              <span class="text-body-2 font-weight-medium">Unlicense</span>
             </div>
             <v-divider class="my-2" />
             <div class="d-flex align-center">


### PR DESCRIPTION
This pull request makes a small update to the `SettingsView.vue` file, changing the displayed license from "MIT" to "Unlicense".